### PR TITLE
feat(auth): register/token-json/me with bcrypt + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# coulisses_crew
+# Coulisses Crew
+
+Minimal authentication service using FastAPI with bcrypt hashing.
+
+## Run
+
+```
+uvicorn app.main:app --reload
+```
+
+See `frontend/index.html` for a simple login form.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+import bcrypt
+import secrets
+
+from . import storage
+
+router = APIRouter()
+security = HTTPBearer()
+tokens: dict[str, int] = {}
+
+class UserIn(BaseModel):
+    username: str
+    password: str
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    role: str
+
+class TokenRequest(BaseModel):
+    username: str
+    password: str
+
+class TokenResponse(BaseModel):
+    access_token: str
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    user_id = tokens.get(token)
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    data = storage.load_data()
+    user = next((u for u in data['users'] if u['id'] == user_id), None)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    return user
+
+def require_role(role: str):
+    def dependency(user: dict = Depends(get_current_user)):
+        if user['role'] != role:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Forbidden')
+        return user
+    return dependency
+
+@router.post('/register', response_model=UserOut)
+def register(user: UserIn):
+    data = storage.load_data()
+    if any(u['username'] == user.username for u in data['users']):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Username already taken')
+    hashed = bcrypt.hashpw(user.password.encode(), bcrypt.gensalt()).decode()
+    user_id = len(data['users']) + 1
+    new_user = {'id': user_id, 'username': user.username, 'password_hash': hashed, 'role': 'intermittent'}
+    data['users'].append(new_user)
+    storage.save_data(data)
+    return {'id': user_id, 'username': user.username, 'role': 'intermittent'}
+
+@router.post('/token-json', response_model=TokenResponse)
+def token_json(req: TokenRequest):
+    data = storage.load_data()
+    user = next((u for u in data['users'] if u['username'] == req.username), None)
+    if not user or not bcrypt.checkpw(req.password.encode(), user['password_hash'].encode()):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid credentials')
+    token = secrets.token_hex(16)
+    tokens[token] = user['id']
+    return {'access_token': token}
+
+@router.get('/me', response_model=UserOut)
+def me(user: dict = Depends(get_current_user)):
+    return {'id': user['id'], 'username': user['username'], 'role': user['role']}

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .auth import router as auth_router
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['http://localhost:5173'],
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+app.include_router(auth_router, prefix='/auth', tags=['auth'])

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+from typing import Dict, Any, List
+
+DATA_FILE = Path('data/data.json')
+
+def _init_storage() -> None:
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not DATA_FILE.exists():
+        with DATA_FILE.open('w') as f:
+            json.dump({'users': []}, f)
+
+def load_data() -> Dict[str, Any]:
+    _init_storage()
+    with DATA_FILE.open() as f:
+        return json.load(f)
+
+def save_data(data: Dict[str, Any]) -> None:
+    _init_storage()
+    with DATA_FILE.open('w') as f:
+        json.dump(data, f)

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,1 @@
+{"users": [{"id": 1, "username": "alice", "password_hash": "$2b$12$FbXLPdu8ok45mp02dE09aOkp20E3bBz.1ETr9QhcqZIYzKzuRqy.G", "role": "intermittent"}]}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Auth Demo</title>
+</head>
+<body>
+  <div id="topbar">
+    <form id="login-form">
+      <input type="text" id="username" placeholder="username" required />
+      <input type="password" id="password" placeholder="password" required />
+      <button type="submit">Login</button>
+    </form>
+    <span id="status"></span>
+  </div>
+  <script>
+    const form = document.getElementById('login-form');
+    const statusEl = document.getElementById('status');
+    const savedToken = localStorage.getItem('token');
+    if (savedToken) {
+      statusEl.textContent = 'Connected';
+    }
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const resp = await fetch('http://localhost:8000/auth/token-json', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        localStorage.setItem('token', data.access_token);
+        statusEl.textContent = `Connected as ${username}`;
+      } else {
+        statusEl.textContent = 'Login failed';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+bcrypt
+pytest
+httpx

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+# ensure a clean data directory for tests
+if os.path.exists('data'):
+    shutil.rmtree('data')
+
+client = TestClient(app)
+
+def test_register_then_login_me():
+    resp = client.post('/auth/register', json={'username': 'alice', 'password': 'wonderland'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['username'] == 'alice'
+    assert data['role'] == 'intermittent'
+
+    resp = client.post('/auth/token-json', json={'username': 'alice', 'password': 'wonderland'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+
+    resp = client.get('/auth/me', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    profile = resp.json()
+    assert profile['username'] == 'alice'
+    assert profile['role'] == 'intermittent'


### PR DESCRIPTION
## Summary
- add FastAPI auth endpoints with bcrypt hashing and simple token storage
- persist users to JSON file via storage helper
- include frontend login form and CORS configuration
- test registration, token issuance and profile access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4d1e7f14833089a7bdc85a443ce2