### PR TITLE
feat(missions): CRUD + filters + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+.pytest_cache/

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,85 @@
+from fastapi import FastAPI, HTTPException, Query
+from typing import List, Optional
+from datetime import datetime
+
+from .schemas import Mission, MissionCreate, MissionUpdate
+
+app = FastAPI()
+
+# In-memory storage
+MISSIONS: List[Mission] = []
+NEXT_ID = 1
+
+
+def apply_filters(
+    missions: List[Mission],
+    q: Optional[str],
+    status: Optional[str],
+    date_from: Optional[datetime],
+    date_to: Optional[datetime],
+    role: Optional[str],
+):
+    result = missions
+    if q:
+        result = [m for m in result if q.lower() in m.title.lower()]
+    if status:
+        result = [m for m in result if m.status == status]
+    if date_from:
+        result = [m for m in result if m.start >= date_from]
+    if date_to:
+        result = [m for m in result if m.end <= date_to]
+    if role:
+        result = [m for m in result if any(p.label == role for p in m.positions)]
+    return result
+
+
+@app.get("/missions", response_model=List[Mission])
+def list_missions(
+    q: Optional[str] = None,
+    status: Optional[str] = Query(None, regex="^(draft|published)$"),
+    date_from: Optional[datetime] = None,
+    date_to: Optional[datetime] = None,
+    role: Optional[str] = None,
+    page: int = 1,
+    per_page: int = 10,
+):
+    missions = apply_filters(MISSIONS, q, status, date_from, date_to, role)
+    start = (page - 1) * per_page
+    end = start + per_page
+    return missions[start:end]
+
+
+@app.post("/missions", response_model=Mission, status_code=201)
+def create_mission(mission: MissionCreate):
+    global NEXT_ID
+    mission_data = Mission(id=NEXT_ID, **mission.dict())
+    MISSIONS.append(mission_data)
+    NEXT_ID += 1
+    return mission_data
+
+
+@app.get("/missions/{mission_id}", response_model=Mission)
+def get_mission(mission_id: int):
+    for m in MISSIONS:
+        if m.id == mission_id:
+            return m
+    raise HTTPException(status_code=404, detail="Mission not found")
+
+
+@app.put("/missions/{mission_id}", response_model=Mission)
+def update_mission(mission_id: int, mission: MissionUpdate):
+    for idx, m in enumerate(MISSIONS):
+        if m.id == mission_id:
+            updated = Mission(id=mission_id, **mission.dict())
+            MISSIONS[idx] = updated
+            return updated
+    raise HTTPException(status_code=404, detail="Mission not found")
+
+
+@app.delete("/missions/{mission_id}", status_code=204)
+def delete_mission(mission_id: int):
+    for idx, m in enumerate(MISSIONS):
+        if m.id == mission_id:
+            del MISSIONS[idx]
+            return
+    raise HTTPException(status_code=404, detail="Mission not found")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone, timedelta
+from typing import List, Optional, Dict
+
+from pydantic import BaseModel, Field, validator, root_validator
+
+UTC_PLUS_4 = timezone(timedelta(hours=4))
+
+
+class Position(BaseModel):
+    label: str
+    count: int = Field(..., ge=1)
+    skills: Dict[str, str] = Field(default_factory=dict)
+
+
+class MissionBase(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+    location: Optional[str] = None
+    status: str = Field("draft", regex="^(draft|published)$")
+    positions: List[Position] = Field(default_factory=list)
+
+    @validator("start", "end", pre=True)
+    def ensure_timezone(cls, v):
+        # Parse string and set default timezone to UTC+4 if none
+        if isinstance(v, str):
+            dt = datetime.fromisoformat(v)
+        else:
+            dt = v
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC_PLUS_4)
+        return dt
+
+    @root_validator
+    def check_dates(cls, values):
+        start = values.get("start")
+        end = values.get("end")
+        if start and end and not start < end:
+            raise ValueError("start must be before end")
+        return values
+
+
+class MissionCreate(MissionBase):
+    pass
+
+
+class MissionUpdate(MissionBase):
+    pass
+
+
+class Mission(MissionBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Missions</title>
+</head>
+<body>
+  <h1>Missions</h1>
+  <button id="new">Nouvelle mission</button>
+  <table border="1" id="missions">
+    <thead><tr><th>ID</th><th>Title</th><th>Status</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <div id="form" style="display:none;">
+    <h2>Create Mission</h2>
+    <label>Title <input type="text" id="title" /></label><br />
+    <label>Start <input type="datetime-local" id="start" /></label><br />
+    <label>End <input type="datetime-local" id="end" /></label><br />
+    <button id="save">Save</button>
+  </div>
+
+<script>
+async function loadMissions(){
+  const res = await fetch('/missions');
+  const missions = await res.json();
+  const tbody=document.querySelector('#missions tbody');
+  tbody.innerHTML='';
+  missions.forEach(m=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${m.id}</td><td>${m.title}</td><td>${m.status}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('new').onclick=()=>{
+  document.getElementById('form').style.display='block';
+};
+
+document.getElementById('save').onclick=async()=>{
+  const payload={
+    title: document.getElementById('title').value,
+    start: document.getElementById('start').value,
+    end: document.getElementById('end').value,
+    status: 'draft',
+    positions: []
+  };
+  await fetch('/missions',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+  document.getElementById('form').style.display='none';
+  loadMissions();
+};
+
+loadMissions();
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.103.0
+uvicorn==0.23.2
+pydantic==1.10.7
+pytest==7.4.0
+httpx==0.24.1

--- a/tests/test_missions.py
+++ b/tests/test_missions.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from backend.main import app
+
+client = TestClient(app)
+
+
+def sample_mission():
+    return {
+        "title": "Sample",
+        "start": "2023-01-01T10:00:00",
+        "end": "2023-01-01T12:00:00",
+        "location": "HQ",
+        "status": "draft",
+        "positions": [
+            {"label": "medic", "count": 2, "skills": {"first_aid": "advanced"}}
+        ],
+    }
+
+
+def test_create_list_update_delete_ok():
+    payload = sample_mission()
+    resp = client.post("/missions", json=payload)
+    assert resp.status_code == 201
+    mission = resp.json()
+    assert mission["id"] == 1
+
+    resp = client.get("/missions")
+    assert resp.status_code == 200
+    missions = resp.json()
+    assert len(missions) == 1
+
+    update = payload.copy()
+    update["title"] = "Updated"
+    resp = client.put("/missions/1", json=update)
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated"
+
+    resp = client.delete("/missions/1")
+    assert resp.status_code == 204
+    resp = client.get("/missions")
+    assert resp.json() == []
+
+
+def test_create_invalid_dates_422():
+    payload = sample_mission()
+    payload["end"] = payload["start"]
+    resp = client.post("/missions", json=payload)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add FastAPI missions CRUD with filtering and temporal validation
- include frontend page to list and create missions
- cover workflows with pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4e04ee1483308803e79ff9b1ea49