### PR TITLE
feat(assignments): POST /missions/{id}/assign + tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,68 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Optional, List, Dict
+from enum import Enum
+from itertools import count
+
+app = FastAPI()
+
+
+class Status(str, Enum):
+    invited = "invited"
+    confirmed = "confirmed"
+    declined = "declined"
+    tentative = "tentative"
+
+
+class Assignment(BaseModel):
+    id: int
+    mission_id: int
+    user_id: Optional[int] = None
+    role_label: str
+    status: Status
+
+
+class AssignmentIn(BaseModel):
+    role_label: str
+    user_id: Optional[int] = None
+    status: Optional[Status] = Status.invited
+
+
+class Position(BaseModel):
+    label: str
+    count: int
+
+
+class Mission(BaseModel):
+    id: int
+    positions: List[Position]
+    assignments: List[Assignment] = []
+
+
+missions: Dict[int, Mission] = {}
+_assignment_id = count(1)
+
+
+@app.post("/missions/{mid}/assign", response_model=Assignment)
+def assign(mid: int, payload: AssignmentIn) -> Assignment:
+    mission = missions.get(mid)
+    if mission is None:
+        raise HTTPException(status_code=404, detail="Mission not found")
+
+    position = next((p for p in mission.positions if p.label == payload.role_label), None)
+    if position is None:
+        raise HTTPException(status_code=422, detail="Invalid role")
+
+    existing = [a for a in mission.assignments if a.role_label == payload.role_label]
+    if len(existing) >= position.count:
+        raise HTTPException(status_code=422, detail="Role capacity exceeded")
+
+    assignment = Assignment(
+        id=next(_assignment_id),
+        mission_id=mid,
+        user_id=payload.user_id,
+        role_label=payload.role_label,
+        status=payload.status or Status.invited,
+    )
+    mission.assignments.append(assignment)
+    return assignment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from app.main import app, missions, Mission, Position
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    missions.clear()
+
+
+def test_assign_ok_then_capacity_exceeded_422():
+    missions[1] = Mission(id=1, positions=[Position(label="pilot", count=1)])
+
+    res1 = client.post("/missions/1/assign", json={"role_label": "pilot", "user_id": 1})
+    assert res1.status_code == 200, res1.text
+
+    res2 = client.post("/missions/1/assign", json={"role_label": "pilot", "user_id": 2})
+    assert res2.status_code == 422
+    assert "capacity" in res2.json()["detail"]
+
+
+def test_assign_invalid_role_422():
+    missions[1] = Mission(id=1, positions=[Position(label="pilot", count=1)])
+
+    res = client.post("/missions/1/assign", json={"role_label": "copilot", "user_id": 1})
+    assert res.status_code == 422
+    assert "Invalid role" in res.json()["detail"]


### PR DESCRIPTION
## Summary
- add in-memory assignment model and POST `/missions/{mid}/assign` endpoint with role and capacity validation
- cover assignment creation and error scenarios with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f515725508330a2647295807dfde1