### PR TITLE
feat(seed): seed_plus.py + seed_demo.ps1

### DIFF
--- a/scripts/seed_demo.ps1
+++ b/scripts/seed_demo.ps1
@@ -1,0 +1,28 @@
+# Simple demo seeding script
+param(
+    [int]$Missions = 3
+)
+
+$base = "http://localhost:8000"
+
+# ping health endpoint
+Invoke-WebRequest "$base/healthz" | Out-Null
+
+# register admin if missing
+try {
+    $body = @{username="admin"; password="admin"} | ConvertTo-Json
+    Invoke-RestMethod -Method Post -Uri "$base/auth/register" -Body $body -ContentType "application/json" | Out-Null
+} catch {
+    # ignore errors
+}
+
+# login to get token
+$login = @{username="admin"; password="admin"} | ConvertTo-Json
+$token = (Invoke-RestMethod -Method Post -Uri "$base/auth/token-json" -Body $login -ContentType "application/json").access_token
+$headers = @{Authorization="Bearer $token"}
+
+for ($i = 1; $i -le $Missions; $i++) {
+    $day = (Get-Date).AddDays($i-1).ToString("yyyy-MM-dd")
+    $payload = @{title="Mission $i"; day=$day} | ConvertTo-Json
+    Invoke-RestMethod -Method Post -Uri "$base/missions" -Headers $headers -Body $payload -ContentType "application/json"
+}

--- a/scripts/seed_plus.py
+++ b/scripts/seed_plus.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Seed data for development/demo purposes."""
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+import bcrypt
+
+DATA_FILE = Path('data/data.json')
+
+
+def _init_storage(reset: bool = False) -> dict:
+    if reset and DATA_FILE.exists():
+        DATA_FILE.unlink()
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not DATA_FILE.exists():
+        with DATA_FILE.open('w') as f:
+            json.dump({'users': [], 'missions': [], 'assignments': []}, f)
+    with DATA_FILE.open() as f:
+        return json.load(f)
+
+
+def _save_storage(data: dict) -> None:
+    with DATA_FILE.open('w') as f:
+        json.dump(data, f)
+
+
+def seed_users(data: dict, count: int) -> None:
+    users = data['users']
+    users.clear()
+    # admin user
+    pwd = bcrypt.hashpw(b'admin', bcrypt.gensalt()).decode()
+    users.append({'id': 1, 'username': 'admin', 'password_hash': pwd, 'role': 'admin'})
+    uid = 2
+    for i in range(count):
+        pwd = bcrypt.hashpw(b'password', bcrypt.gensalt()).decode()
+        users.append({'id': uid, 'username': f'user{i+1}', 'password_hash': pwd, 'role': 'intermittent'})
+        uid += 1
+
+
+def seed_missions(data: dict, count: int, days: int) -> None:
+    missions = data['missions']
+    assignments = data['assignments']
+    missions.clear()
+    assignments.clear()
+    today = dt.date.today()
+    mid = 1
+    aid = 1
+    user_ids = [u['id'] for u in data['users'] if u['role'] == 'intermittent']
+    for i in range(count):
+        day = today + dt.timedelta(days=i % max(days, 1))
+        missions.append({'id': mid, 'title': f'Mission {i+1}', 'day': day.isoformat()})
+        if user_ids:
+            uid = user_ids[i % len(user_ids)]
+            assignments.append({'id': aid, 'mission_id': mid, 'user_id': uid})
+            aid += 1
+        mid += 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Seed demo data.')
+    parser.add_argument('--reset', action='store_true', help='Reset data file before seeding')
+    parser.add_argument('--users', type=int, default=0, help='Number of intermittent users to create')
+    parser.add_argument('--missions', type=int, default=0, help='Number of missions to create')
+    parser.add_argument('--days', type=int, default=1, help='Spread missions over this many days')
+    parser.add_argument('--all', action='store_true', help='Seed everything')
+    parser.add_argument('--force-insert', action='store_true', help='Ignored, for compatibility')
+    args = parser.parse_args()
+
+    data = _init_storage(reset=args.reset)
+    if args.all:
+        seed_users(data, args.users)
+        seed_missions(data, args.missions, args.days)
+    else:
+        if args.users:
+            seed_users(data, args.users)
+        if args.missions:
+            seed_missions(data, args.missions, args.days)
+    _save_storage(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,23 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+def run_seed(users=2, missions=3, days=2):
+    cmd = [sys.executable, 'scripts/seed_plus.py', '--reset', '--users', str(users), '--missions', str(missions), '--days', str(days), '--all']
+    subprocess.run(cmd, check=True)
+
+def load():
+    with open('data/data.json') as f:
+        return json.load(f)
+
+def test_seed_inserts_consistent_ids():
+    run_seed()
+    first = load()
+    run_seed()
+    second = load()
+    assert [u['id'] for u in first['users']] == [u['id'] for u in second['users']]
+    assert [m['id'] for m in first['missions']] == [m['id'] for m in second['missions']]
+    assert [a['id'] for a in first['assignments']] == [a['id'] for a in second['assignments']]
+    # cleanup
+    Path('data/data.json').unlink()


### PR DESCRIPTION
## Summary
- add Python seeding utility with options for users, missions and reset
- include PowerShell demo script that pings API, registers/login admin and creates missions
- test that seeding generates consistent IDs across runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f56db9e348330aff476164f2203c5