### PR TITLE
feat(front): services + hooks relies a l'API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8001

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+import * as authService from '../services/auth';
+
+interface User {
+  id: number;
+  username: string;
+  role: string;
+  [key: string]: unknown;
+}
+
+export function useAuth() {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const { access_token } = await authService.login({ username, password });
+    setToken(access_token);
+    const me = await authService.me(access_token);
+    setUser(me);
+  }, []);
+
+  const fetchMe = useCallback(async () => {
+    if (!token) return;
+    const me = await authService.me(token);
+    setUser(me);
+  }, [token]);
+
+  const updatePrefs = useCallback(
+    async (prefs: Record<string, unknown>) => {
+      if (!token) return;
+      await authService.prefs(token, prefs);
+    },
+    [token]
+  );
+
+  return { token, user, login, fetchMe, updatePrefs };
+}

--- a/frontend/src/hooks/useMissions.ts
+++ b/frontend/src/hooks/useMissions.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+import * as missionService from '../services/missions';
+
+interface Mission {
+  id: number;
+  [key: string]: unknown;
+}
+
+export function useMissions(token: string | null) {
+  const [missions, setMissions] = useState<Mission[]>([]);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    const data = await missionService.list(token);
+    setMissions(data);
+  }, [token]);
+
+  const createMission = useCallback(
+    async (mission: Record<string, unknown>) => {
+      if (!token) return;
+      const created = await missionService.create(token, mission);
+      setMissions((m) => [...m, created]);
+    },
+    [token]
+  );
+
+  const updateMission = useCallback(
+    async (id: number, mission: Record<string, unknown>) => {
+      if (!token) return;
+      const updated = await missionService.update(token, id, mission);
+      setMissions((m) => m.map((mi) => (mi.id === id ? updated : mi)));
+    },
+    [token]
+  );
+
+  const deleteMission = useCallback(
+    async (id: number) => {
+      if (!token) return;
+      await missionService.remove(token, id);
+      setMissions((m) => m.filter((mi) => mi.id !== id));
+    },
+    [token]
+  );
+
+  const assignMission = useCallback(
+    async (id: number, userId: number) => {
+      if (!token) return;
+      const updated = await missionService.assign(token, id, userId);
+      setMissions((m) => m.map((mi) => (mi.id === id ? updated : mi)));
+    },
+    [token]
+  );
+
+  return { missions, load, createMission, updateMission, deleteMission, assignMission };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,16 @@
+export const baseURL = import.meta.env.VITE_API_URL;
+
+export async function apiFetch(path: string, options: RequestInit = {}) {
+  const url = `${baseURL}${path}`;
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {})
+  } as Record<string, string>;
+  const resp = await fetch(url, { ...options, headers });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`API request failed: ${resp.status} ${text}`);
+  }
+  if (resp.status === 204) return null;
+  return resp.json();
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from '../lib/api';
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface TokenResponse {
+  access_token: string;
+}
+
+export function login(data: LoginRequest): Promise<TokenResponse> {
+  return apiFetch('/auth/token-json', {
+    method: 'POST',
+    body: JSON.stringify(data)
+  });
+}
+
+export function me(token: string) {
+  return apiFetch('/auth/me', {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+export function prefs(token: string, prefs: Record<string, unknown>) {
+  return apiFetch('/auth/me/prefs', {
+    method: 'PUT',
+    body: JSON.stringify(prefs),
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}

--- a/frontend/src/services/missions.ts
+++ b/frontend/src/services/missions.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from '../lib/api';
+
+export function list(token: string) {
+  return apiFetch('/missions', {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+export function create(token: string, mission: Record<string, unknown>) {
+  return apiFetch('/missions', {
+    method: 'POST',
+    body: JSON.stringify(mission),
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+export function update(token: string, id: number, mission: Record<string, unknown>) {
+  return apiFetch(`/missions/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(mission),
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+export function remove(token: string, id: number) {
+  return apiFetch(`/missions/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+export function assign(token: string, id: number, userId: number) {
+  return apiFetch(`/missions/${id}/assign`, {
+    method: 'POST',
+    body: JSON.stringify({ user_id: userId }),
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}


### PR DESCRIPTION
## Summary
- connect front to API with reusable fetch client
- add auth and mission services
- expose useAuth and useMissions hooks

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5dbbf7c48330b3598bf1a698c0d3