### PR TITLE
Resolve configuration conflicts and expand setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 npm-debug.log
-
+.env
+.venv
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Minimal authentication service using FastAPI with bcrypt hashing.
 
 A docker-compose setup runs the API and the front-end.
 
+Copy `.env.example` to `.env` to customize settings like the API URL.
+
 ### Windows (PowerShell)
 
 ```powershell
@@ -20,6 +22,15 @@ A docker-compose setup runs the API and the front-end.
 docker compose up -d --build
 docker compose exec api pytest -q
 docker compose down -v
+```
+
+### Testing
+
+Run the Node and Python test suites locally:
+
+```bash
+npm test
+pytest -q
 ```
 
 ### Local URLs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   api:
     image: python:3.11-slim
     working_dir: /app/backend
+    env_file: .env
     volumes:
       - ./:/app/backend
       - data:/data
@@ -12,6 +13,7 @@ services:
   web:
     image: node:18
     working_dir: /app
+    env_file: .env
     volumes:
       - ./frontend:/app
       - data:/data

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
     <span id="status"></span>
   </div>
   <script>
+    const API_URL = window.API_URL || 'http://localhost:8000';
     const form = document.getElementById('login-form');
     const statusEl = document.getElementById('status');
     const savedToken = localStorage.getItem('token');
@@ -24,7 +25,7 @@
       e.preventDefault();
       const username = document.getElementById('username').value;
       const password = document.getElementById('password').value;
-      const resp = await fetch('http://localhost:8000/auth/token-json', {
+      const resp = await fetch(`${API_URL}/auth/token-json`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })
@@ -34,6 +35,7 @@
         localStorage.setItem('token', data.access_token);
         statusEl.textContent = `Connected as ${username}`;
       } else {
+        localStorage.removeItem('token');
         statusEl.textContent = 'Login failed';
       }
     });


### PR DESCRIPTION
## Summary
- ignore local environment and Python cache files
- document environment setup and testing commands
- load env vars in docker compose and allow configurable API URL in frontend

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f60c5404c83308b197c2a39945341